### PR TITLE
담당 컴포넌트 useQuery 연결 및 지도 api 모듈로 분리, 마커생성 제작, 로드뷰 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,10 @@
 {
-  "singleQuote": true,
+  "singleQuote": false,
   "semi": true,
   "tabWidth": 2,
   "trailingComma": "all",
   "printWidth": 120,
   "endOfLine": "auto",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "quoteProps": "preserve"
 }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= VITE_KAKO_MAP_API %>"></script>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= VITE_KAKO_MAP_API %>&libraries=services"
+    ></script>
     <script>
       if ('serviceWorker' in navigator) {
         // Register a service worker hosted at the root of the

--- a/src/components/booking/OfficeOptions.tsx
+++ b/src/components/booking/OfficeOptions.tsx
@@ -1,11 +1,32 @@
 import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { changeOptionName } from '../../pages/BookingOptionIcon';
+import { ObjectType } from '../../pages/BookingOptionIcon';
+
+type PropsOptionType = {
+  [key: string]: boolean;
+};
 
 type propsType = {
   width?: string;
   needReviewCount?: boolean;
+  OptionData: PropsOptionType;
 };
 
 export const OfficeOptions = (props: propsType) => {
+  console.log(props);
+  const [optionData, setOptionData] = useState<ObjectType[]>([]);
+  useEffect(() => {
+    if (props.OptionData) {
+      const keys = Object.keys(props.OptionData);
+      const changeArr = changeOptionName(keys);
+      setOptionData(changeArr);
+      if (optionData.length >= 1) {
+        console.log(optionData);
+      }
+    }
+  }, []);
+
   return (
     <>
       <div className={`shadow-lg ${props.width && props.width}  py-4 rounded-lg sm:px-4 md:px-12 lg:px-16`}>
@@ -26,10 +47,17 @@ export const OfficeOptions = (props: propsType) => {
         <div className={`${props.needReviewCount && 'border-b border-solid border-accent pb-4 mb-4'}`}>
           <div className="w-3/6 text-base">
             {/* p태그로 서버에서 받아오는 옵션을 반복문으로 넣어야함 */}
-            <p>옵션1</p>
-            <p>옵션2</p>
-            <p>옵션3</p>
-            <p>옵션4</p>
+            {optionData.length >= 1 &&
+              optionData.map((item, index) => {
+                return (
+                  <>
+                    <p key={index} className="flex items-center text-base mb-1">
+                      <span className="mr-1">{item.Icon}</span>
+                      <span>{item.name}</span>
+                    </p>
+                  </>
+                );
+              })}
           </div>
         </div>
         {props.needReviewCount && (

--- a/src/components/common/MaxCapacityDropDown.tsx
+++ b/src/components/common/MaxCapacityDropDown.tsx
@@ -1,11 +1,17 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RiArrowDropDownLine } from 'react-icons/ri';
 
-
-export const MaxCapacityDropDown = (props: { width: string }): JSX.Element => {
+export const MaxCapacityDropDown = (props: {
+  width: string;
+  setMaxPeople?: React.Dispatch<React.SetStateAction<boolean>>;
+}): JSX.Element => {
   // width로 넓이를 지정할 수 있습니다. ex) w-52, w-full
   const [selectedItem, setSelectedItem] = useState('');
   const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (props.setMaxPeople && selectedItem !== '') props.setMaxPeople(true);
+  }, [selectedItem]);
 
   const handleItemClick = (item: string) => {
     setSelectedItem(item);
@@ -20,12 +26,14 @@ export const MaxCapacityDropDown = (props: { width: string }): JSX.Element => {
   return (
     <>
       <div className={`form-control  ${props.width}`}>
-
         <div className="dropdown">
           <label
             tabIndex={0}
             className="group btn btn-primary btn-outline justify-between w-full"
             onClick={toggleDropDown}
+            onChange={() => {
+              props.setMaxPeople ? props.setMaxPeople(true) : null;
+            }}
           >
             <span className="label-text font-medium group-hover:text-white">
               {selectedItem || <span className="text-sm font-medium text-info">최대인원 수</span>}

--- a/src/fetch/api.ts
+++ b/src/fetch/api.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+// 지금은 모두 같지만 추후 url을 변경해야합니다.
+
+export const fetchBookMarkData = () =>
+  axios.get("https://my-json-server.typicode.com/fefdfea1/jsonData/db").then(res => res.data);
+
+export const fetchMyBookingsData = () =>
+  axios.get("https://my-json-server.typicode.com/fefdfea1/jsonData/db").then(res => res.data);
+
+export const fetchBookingData = () =>
+  axios.get("https://my-json-server.typicode.com/fefdfea1/jsonData/db").then(res => res.data);
+
+export const fetchMyPageData = () =>
+  axios.get("https://my-json-server.typicode.com/fefdfea1/jsonData2/db").then(res => res.data);

--- a/src/pages/BookingOptionIcon.tsx
+++ b/src/pages/BookingOptionIcon.tsx
@@ -1,0 +1,57 @@
+//에어컨
+import { TbAirConditioningDisabled } from 'react-icons/tb';
+//도어락
+import { RiDoorLockBoxFill } from 'react-icons/ri';
+//라운지
+import { GrLounge } from 'react-icons/gr';
+//화이트 보드
+import { FaChalkboardTeacher } from 'react-icons/fa';
+//카페
+import { IoIosCafe } from 'react-icons/io';
+//팩스
+import { FaFax } from 'react-icons/fa';
+//부엌
+import { FaKitchenSet } from 'react-icons/Fa6';
+//인터넷
+import { MdOutlineSignalWifiStatusbarConnectedNoInternet4 } from 'react-icons/md';
+//복사기
+import { AiFillCopy } from 'react-icons/ai';
+//난방기
+import { GiFireplace } from 'react-icons/gi';
+//개인 라커
+import { PiLockersFill } from 'react-icons/pi';
+//샤워실
+import { FaShower, FaParking } from 'react-icons/fa';
+//택배 , 프로젝터
+import { BsFillBoxSeamFill, BsFillProjectorFill } from 'react-icons/bs';
+//창고
+import { TbBuildingWarehouse } from 'react-icons/tb';
+import { IconType } from 'react-icons';
+
+type OptionType = string[];
+
+export type ObjectType = {
+  name?: string;
+  Icon?: JSX.Element;
+};
+
+export const changeOptionName = (data: OptionType) => {
+  const changeArr: ObjectType[] = [];
+  data.forEach(element => {
+    const createObject: ObjectType = {};
+    switch (element) {
+      case 'haveHeater':
+        createObject.name = '난방기';
+        createObject.Icon = <GiFireplace />;
+        changeArr.push(createObject);
+        break;
+      case 'haveWhiteBoard':
+        createObject.name = '화이트보드';
+        createObject.Icon = <FaChalkboardTeacher />;
+        changeArr.push(createObject);
+        break;
+    }
+  });
+
+  return changeArr;
+};

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,16 +1,18 @@
-import { Title } from '../components/common/Title';
-import { TitleAndDesc } from '../components/common/TitleAndDesc';
-import { BackgroundCover } from '../components/common/BackgroundCover';
-import { Modal } from '../components/common/Modal';
-import { useLayoutEffect, useState } from 'react';
-import { cacheChargeModalStateFn } from './MyPageModalState';
-import { pullCacheModalStateFn } from './MyPageModalState';
-import { useEffect, useRef } from 'react';
-import { changeProfile, removeProfile } from './MyPageChangeProfile';
-import { setEditClass, mypageBlueEventHandler } from './MypageFouseHandler';
-import { Link } from 'react-router-dom';
-import axios from 'axios';
-import styled from '@emotion/styled';
+import { Title } from "../components/common/Title";
+import { TitleAndDesc } from "../components/common/TitleAndDesc";
+import { BackgroundCover } from "../components/common/BackgroundCover";
+import { Modal } from "../components/common/Modal";
+import { useState } from "react";
+import { cacheChargeModalStateFn } from "./MyPageModalState";
+import { pullCacheModalStateFn } from "./MyPageModalState";
+import { useEffect, useRef } from "react";
+import { changeProfile, removeProfile } from "./MyPageChangeProfile";
+import { setEditClass, mypageBlueEventHandler } from "./MypageFouseHandler";
+import { Link } from "react-router-dom";
+import { useQuery } from "react-query";
+import { fetchMyPageData } from "../fetch/api";
+import styled from "@emotion/styled";
+import { AxiosError } from "axios";
 
 type fetchDataType = {
   email: string;
@@ -20,6 +22,14 @@ type fetchDataType = {
   roles: string;
 };
 
+const defaultUserData = {
+  email: "",
+  id: "",
+  name: "",
+  point: 0,
+  roles: "",
+};
+
 const arr = Array.from({ length: 10 });
 
 //Search와 마찬가지로 클린업 함수 작성을 위해 따로 파일로 만들지 않았습니다
@@ -27,23 +37,24 @@ export const MyPage = () => {
   const [cacheChargeModalState, setcacheChargeModalState] = useState<boolean>(false);
   const [pullCacheModalState, setpullCacheModalState] = useState<boolean>(false);
   const [OwnerState, setOwnerState] = useState<boolean>(false);
-  const [fetchUserData, setUserData] = useState<fetchDataType>();
+  const [fetchUserData, setUserData] = useState<fetchDataType>(defaultUserData);
   const cacheChargeButtonDom = useRef<HTMLButtonElement>(null);
   const pullCacheButtonDom = useRef<HTMLButtonElement>(null);
   const imageDom = useRef<HTMLImageElement>(null);
   const nameInputDom = useRef<HTMLInputElement>(null);
   console.log(setOwnerState);
+  const { data } = useQuery("getData", fetchMyPageData);
 
   useEffect(() => {
     //클린업 함수를 위해 해당 부분에 작성
     const windowEventHandler = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
-      if (!target.classList.contains('charge')) {
-        if (target.closest('.Modal') === null) {
+      if (!target.classList.contains("charge")) {
+        if (target.closest(".Modal") === null) {
           if (
-            cacheChargeButtonDom.current?.classList.contains('active') ||
-            pullCacheButtonDom.current?.classList.contains('active')
+            cacheChargeButtonDom.current?.classList.contains("active") ||
+            pullCacheButtonDom.current?.classList.contains("active")
           ) {
             setpullCacheModalState(false);
             setcacheChargeModalState(false);
@@ -52,21 +63,18 @@ export const MyPage = () => {
       }
     };
 
-    window.addEventListener('click', windowEventHandler);
+    window.addEventListener("click", windowEventHandler);
 
     return () => {
-      window.removeEventListener('click', windowEventHandler);
+      window.removeEventListener("click", windowEventHandler);
     };
   }, []);
 
-  useLayoutEffect(() => {
-    const fetchData = async () => {
-      const response = await axios.get('http://localhost:3000/Mypage');
-      console.log(response);
-      setUserData(response.data);
-    };
-    fetchData();
-  }, []);
+  useEffect(() => {
+    if (data) {
+      setUserData(data.MyPage);
+    }
+  }, [data]);
 
   return (
     <div className="relative mb-10">
@@ -76,7 +84,7 @@ export const MyPage = () => {
           {OwnerState && (
             <ShowMyOfficeButotn>
               <button className="w-52 btn btn-outline btn-primary">
-                <Link to={'/MyOffice'} className="w-52 btn btn-outline btn-primary absolute right-0 top-0">
+                <Link to={"/MyOffice"} className="w-52 btn btn-outline btn-primary absolute right-0 top-0">
                   나의 지점 보기
                 </Link>
               </button>
@@ -120,7 +128,7 @@ export const MyPage = () => {
             <div className="mb-6 pb-4 border-b border-solid border-accent">
               <TitleAndDesc
                 title="아이디"
-                description={`${fetchUserData ? fetchUserData.email : '불러오기에 실패하였습니다'}`}
+                description={`${fetchUserData ? fetchUserData.email : "불러오기에 실패하였습니다"}`}
               />
             </div>
             <div className="mb-6 pb-4 border-b border-solid border-accent relative leading-loose">
@@ -131,7 +139,7 @@ export const MyPage = () => {
                   type="text"
                   id="EditIdInput"
                   className="text-base pl-4 mr font-bold bg-transparent"
-                  defaultValue={`${fetchUserData ? fetchUserData.name : ''}`}
+                  defaultValue={`${fetchUserData ? fetchUserData.name : ""}`}
                   readOnly
                   ref={nameInputDom}
                   onBlur={() => {
@@ -153,14 +161,14 @@ export const MyPage = () => {
             <div className="mb-6 pb-4 border-b border-solid border-accent">
               <TitleAndDesc
                 title="현재 포인트"
-                description={`${fetchUserData ? fetchUserData.point : '불러오기에 실패하였습니다'}`}
+                description={`${fetchUserData ? fetchUserData.point : "불러오기에 실패하였습니다"}`}
                 type="point"
               />
             </div>
             <div className="flex justify-between gap-x-9">
               <button
                 ref={cacheChargeButtonDom}
-                className={`btn btn-primary grow charge ${cacheChargeModalState && 'active'}`}
+                className={`btn btn-primary grow charge ${cacheChargeModalState && "active"}`}
                 onClick={() => {
                   cacheChargeModalStateFn(
                     cacheChargeModalState,
@@ -174,7 +182,7 @@ export const MyPage = () => {
               </button>
               <button
                 ref={pullCacheButtonDom}
-                className={`btn btn-primary grow charge ${pullCacheModalState && 'active'}`}
+                className={`btn btn-primary grow charge ${pullCacheModalState && "active"}`}
                 onClick={() => {
                   pullCacheModalStateFn(
                     pullCacheModalState,
@@ -246,7 +254,7 @@ const EditPosition = styled.label`
 
 const ProfilePseudoElements = styled.label`
   &::after {
-    content: '';
+    content: "";
     width: 1px;
     height: 20px;
     position: absolute;
@@ -280,7 +288,7 @@ const ModalPosition = styled.div`
 const ChargeList = styled.div`
   width: 50%;
   &::after {
-    content: '';
+    content: "";
     width: 1px;
     height: 100%;
     position: absolute;

--- a/src/pages/customer/BookMark.tsx
+++ b/src/pages/customer/BookMark.tsx
@@ -1,9 +1,32 @@
 import { BackgroundCover } from '../../components/common/BackgroundCover';
 import { Title } from '../../components/common/Title';
 import { BookMarkOfficeCompo } from './BookMarkOfficeCompo';
+import { useQuery } from 'react-query';
+import { fetchBookMarkData } from '../../fetch/api';
+import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
+
+export type BookMarkDataType = {
+  officeAddress: string;
+  officeName: string;
+};
+
+const defaultValue = [
+  {
+    officeName: '',
+    officeAddress: '',
+  },
+];
+
 export const BookMark = () => {
-  const arr = Array.from({ length: 20 });
+  const [BookMarkData, setBookMarkData] = useState<BookMarkDataType[]>(defaultValue);
+  const { data } = useQuery('BookMark', fetchBookMarkData);
+  useEffect(() => {
+    if (data) {
+      setBookMarkData(data.BookMark.data);
+      console.log(BookMarkData);
+    }
+  }, [data]);
 
   return (
     <div className="mb-10">
@@ -15,9 +38,13 @@ export const BookMark = () => {
         {/* breakPoint별로 grid-cols를 변경해야함 */}
         <div className="grid grid-cols-4 gap-8 mb-8 sm:grid-cols-1 sm:gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 ">
           {/* 데이터를 불러오면 map으로 처리해야하는 부분입니다 */}
-          {arr.map(() => {
+          {BookMarkData.map((item, index) => {
             return (
-              <BookMarkOfficeCompo imgSrc="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRS-IbhTFqh9vemV_FD7WQn48tFhODBKb1kEteLagL2mw&s" />
+              <BookMarkOfficeCompo
+                item={item}
+                imgSrc="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRS-IbhTFqh9vemV_FD7WQn48tFhODBKb1kEteLagL2mw&s"
+                key={index}
+              />
             );
           })}
         </div>

--- a/src/pages/customer/BookMarkOfficeCompo.tsx
+++ b/src/pages/customer/BookMarkOfficeCompo.tsx
@@ -2,9 +2,10 @@ import { OfficeName } from '../../components/booking/Officename';
 import { AiFillStar } from 'react-icons/ai';
 import { Heart } from '../../components/common/Heart';
 import { Link } from 'react-router-dom';
-
+import { BookMarkDataType } from './BookMark';
 type propsType = {
   imgSrc: string;
+  item: BookMarkDataType;
 };
 
 export const BookMarkOfficeCompo = (props: propsType) => {
@@ -17,7 +18,7 @@ export const BookMarkOfficeCompo = (props: propsType) => {
         </figure>
       </Link>
       <div className="flex justify-between relative">
-        <OfficeName name="오피스 이름입니다" address="주소" />
+        <OfficeName name={`${props.item.officeName}`} address={`${props.item.officeAddress}`} />
         <div className="flex items-center absolute top-2 right-2 font-bold text-sm tracking-tight">
           <AiFillStar className="mr-1" />
           <span className="mr-1">(4.91)</span>

--- a/src/pages/customer/BookMarkPrintMap.ts
+++ b/src/pages/customer/BookMarkPrintMap.ts
@@ -1,0 +1,41 @@
+import { BookingDataType } from '../Booking';
+import { corrdinateType } from './BookMarkLoadView';
+
+export const DrawMap = (
+  BookingData: BookingDataType,
+  setOfficePosition: React.Dispatch<React.SetStateAction<corrdinateType | undefined>>,
+) => {
+  let container = document.getElementById('map'); //지도를 담을 영역의 DOM 레퍼런스
+  let options = {
+    //지도를 생성할 때 필요한 기본 옵션
+    center: new window.kakao.maps.LatLng(35.450701, 126.570667), //지도의 중심좌표.
+    level: 3, //지도의 레벨(확대, 축소 정도)
+  };
+
+  let map = new window.kakao.maps.Map(container, options); //지도 생성 및 객체 리턴
+
+  let geocoder = new window.kakao.maps.services.Geocoder();
+  //실제 데이터를 받으면 해당 데이터의 주소로 변경
+  geocoder.addressSearch(BookingData.address, (result: any, status: any) => {
+    // 정상적으로 검색이 완료됐으면
+    if (status === window.kakao.maps.services.Status.OK) {
+      const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
+      setOfficePosition(coords);
+
+      // 결과값으로 받은 위치를 마커로 표시합니다
+      const marker = new window.kakao.maps.Marker({
+        map: map,
+        position: coords,
+      });
+
+      // 인포윈도우로 장소에 대한 설명을 표시합니다
+      const infowindow = new window.kakao.maps.InfoWindow({
+        constcontent: `<div style="width:150px;text-align:center;padding:6px 0;">${BookingData.name}</div>`,
+      });
+      infowindow.open(map, marker);
+
+      // 지도의 중심을 결과값으로 받은 위치로 이동시킵니다
+      map.setCenter(coords);
+    }
+  });
+};

--- a/src/pages/customer/MyBookings.tsx
+++ b/src/pages/customer/MyBookings.tsx
@@ -1,10 +1,31 @@
 import { MyBookingsListCompo } from './MyBookingsListCompo';
 import { BackgroundCover } from '../../components/common/BackgroundCover';
 import { Title } from '../../components/common/Title';
+import { useQuery } from 'react-query';
+import { fetchMyBookingsData } from '../../fetch/api';
+import { useState, useEffect } from 'react';
 
-const arr = Array.from({ length: 10 });
+export type MyBookingsDataType = {
+  endDate: string;
+  isMonthly: boolean;
+  isReviewed: boolean;
+  leaseId: number;
+  leaseStatus: string;
+  location: string;
+  name: string;
+  paymentData: string;
+  startDate: string;
+};
 
 export const MyBookings = () => {
+  const [MyBookingsData, setMyBookingsData] = useState<MyBookingsDataType[]>([]);
+  const { data } = useQuery(['fetchBookingData'], fetchMyBookingsData);
+  useEffect(() => {
+    if (data) {
+      setMyBookingsData(data.content);
+    }
+  }, [data]);
+
   return (
     <div className="w-11/12 mx-auto">
       {/* 각각 데이터의 갯수만큼 반복하여 제작 */}
@@ -12,13 +33,14 @@ export const MyBookings = () => {
         <BackgroundCover>
           <Title>나의 예약</Title>
           <div className="mt-8"></div>
-          {arr.map((_, index) => {
-            return <MyBookingsListCompo type="MyBooking" key={index} />;
+          {MyBookingsData.map((item, index) => {
+            if (item.leaseStatus !== 'EXPIRED') return <MyBookingsListCompo item={item} type="MyBooking" key={index} />;
           })}
           <Title>지난 예약</Title>
           <div className="mt-8">
-            {arr.map((_, index) => {
-              return <MyBookingsListCompo type="last_reservation" key={index} />;
+            {MyBookingsData.map((item, index) => {
+              if (item.leaseStatus === 'EXPIRED')
+                return <MyBookingsListCompo item={item} type="last_reservation" key={index} />;
             })}
           </div>
         </BackgroundCover>

--- a/src/pages/customer/MyBookingsListCompo.tsx
+++ b/src/pages/customer/MyBookingsListCompo.tsx
@@ -1,13 +1,18 @@
 import { OfficeName } from '../../components/booking/Officename';
 import { Heart } from '../../components/common/Heart';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { MyBookingsDataType } from './MyBookings';
+import { useSetStatusText } from './MyBookingsSetStatusText';
 
 type propsType = {
   type?: string;
+  item: MyBookingsDataType;
 };
 
 export const MyBookingsListCompo = (props: propsType) => {
   const [writeReviewState, setReviewState] = useState<boolean>(false);
+  const statePTag = useRef<HTMLParagraphElement>(null);
+  useSetStatusText(statePTag, props.item.leaseStatus);
   return (
     <>
       <div className="flex px-10 sm:px-2 sm:flex-col lg:flex-row mb-8">
@@ -31,7 +36,7 @@ export const MyBookingsListCompo = (props: propsType) => {
               2023년 8월 10일 ~ 2023년 9월 9일
             </p>
             {props.type === 'MyBooking' && (
-              <p className="mb-8">다음 사용자를 위해 기간 내에 오피스를 깨끗히 해주세요.</p>
+              <p className="mb-4">다음 사용자를 위해 기간 내에 오피스를 깨끗히 해주세요.</p>
             )}
           </div>
           <div
@@ -40,6 +45,10 @@ export const MyBookingsListCompo = (props: propsType) => {
               'flex justify-between items-center sm:flex-col sm:items-start lg:flex-row lg:items-center'
             }`}
           >
+            <div className="mb-4">
+              <p className="font-black text-lg">현재 상태</p>
+              <p ref={statePTag} className="text-base"></p>
+            </div>
             <p className="text-base mb-1">2023년 8월 7일 결제 완료</p>
             {props.type === 'MyBooking' && <p className="text-primary">다음 월 정기 결제일은 0000입니다</p>}
             {props.type === 'last_reservation' && (


### PR DESCRIPTION
1. 각 컴포넌트 useQuery를 이용해 github json 데이터를 불러왔습니다.
2. 지도 구현 api를 따로 파일로 모듈화 하였습니다.
3. 로드뷰 아이콘, 로드뷰 구현 완료하였습니다 또한 주소에 따른 마커생성 구현 완료하였습니다.
4. 오늘 의견이 나왔던 Booking의 합계 출력 부분 제작 완료하였습니다.
5. Booking의 option Icon을 추가하는 로직을 만들었습니다
( 어떤 형태로 데이터가 들어오는지 확실하지 않아 모두 추가하지는 못했습니다 )

## BookMarkLoadView 파일이 추가되었습니다.
해당 파일에 로드뷰로 이동하는 로직을 해당 파일에 추가하였습니다.


![스크린샷 2023-08-30 225656](https://github.com/fefdfea1/officeFinder_Front/assets/46808357/99b69ed9-fdb7-47d1-8bf8-752c65ef1eb3)


## BookMarkPrintMap 파일이 추가되었습니다.
지도 생성 및 마커 표시 로직을 해당 파일로 분리하였습니다( 현제 데이터에 아무정보도 없어 이름이 표시되지 않습니다 )

![스크린샷 2023-08-30 225643](https://github.com/fefdfea1/officeFinder_Front/assets/46808357/b810b8d3-843f-4f3b-a897-7a6d4d886af6)

## BookingOptionIcon 파일이 추가되었습니다
Booking의 Option 부분에 아이콘을 추가 할 수 있는 로직을 해당 파일에 추가하였습니

![스크린샷 2023-08-30 225639](https://github.com/fefdfea1/officeFinder_Front/assets/46808357/e53a6068-e4c5-4702-b43a-1f6c275ff078)

## 합계 출력화면

![스크린샷 2023-08-30 230004](https://github.com/fefdfea1/officeFinder_Front/assets/46808357/023b4702-17a4-4918-b15c-daceb2a620af)

